### PR TITLE
fix: don't publish smart contracts

### DIFF
--- a/contracts/core/Cargo.toml
+++ b/contracts/core/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 authors = ["Stellar Development Foundation <info@stellar.org>"]
 license = "Apache-2.0"
 edition = "2021"
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/contracts/smartdeploy/Cargo.toml
+++ b/contracts/smartdeploy/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Stellar Development Foundation <info@stellar.org>"]
 license = "Apache-2.0"
 rust-version = "1.69"
 edition = "2021"
+publish = false
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
Perhaps will in the future, but for now they can be installed via smartdeploy itself.
