### PR TITLE
'Publish' event and events Rust module

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,7 +3,7 @@
 [alias] # command aliases
 bwl = "build --profile release-with-logs"
 install_soroban = "binstall -y --install-path ./target/bin soroban-cli --version 20.0.0-rc.4.1"
-install_soroban_dev = "install --git https://github.com/stellar/soroban-tools --rev v20.1.1 --debug --root ./target soroban-cli"
+install_soroban_dev = "install --git https://github.com/stellar/soroban-tools --rev v20.2.0 --debug --root ./target soroban-cli"
 install_loam = "install --version 0.6.5 --debug --root ./target loam-cli"
 # c = "check"
 # t = "test"

--- a/contracts/smartdeploy/src/events.rs
+++ b/contracts/smartdeploy/src/events.rs
@@ -1,0 +1,41 @@
+use loam_sdk::soroban_sdk::{
+    self, contracttype, Env, Address, IntoVal, Val, String
+};
+use loam_sdk::IntoKey;
+use crate::{
+    version::{ Version, Update },
+    metadata::ContractMetadata
+};
+
+#[contracttype]
+#[derive(IntoKey)]
+pub struct Publish {
+    pub published_name: String,
+    pub author: Address,
+    pub wasm: soroban_sdk::Bytes,
+    pub repo: ContractMetadata,
+    pub kind: Update,
+}
+
+#[contracttype]
+#[derive(IntoKey)]
+pub struct Deploy {
+    pub published_name: String,
+    pub deployed_name: String,
+    pub version: Version,
+    pub deployer: Address,
+    pub contract_id: Address,
+}
+
+pub trait EventPublishable {
+    /// Publish an event on the blockchain
+    fn publish_event(self, env: &Env);
+}
+
+impl<T> EventPublishable for T 
+    where T: soroban_sdk::IntoKey + IntoVal<Env, Val>,
+{
+    fn publish_event(self, env: &Env) {
+        env.events().publish((T::into_key(),), self);  
+    }
+}

--- a/contracts/smartdeploy/src/events.rs
+++ b/contracts/smartdeploy/src/events.rs
@@ -12,7 +12,7 @@ use crate::{
 pub struct Publish {
     pub published_name: String,
     pub author: Address,
-    pub wasm: soroban_sdk::Bytes,
+    pub hash: soroban_sdk::BytesN<32>,
     pub repo: ContractMetadata,
     pub kind: Update,
 }

--- a/contracts/smartdeploy/src/lib.rs
+++ b/contracts/smartdeploy/src/lib.rs
@@ -10,6 +10,7 @@ pub mod metadata;
 pub mod registry;
 pub mod util;
 pub mod version;
+pub mod events;
 
 use error::Error;
 use version::Version;

--- a/contracts/smartdeploy/src/registry/contract.rs
+++ b/contracts/smartdeploy/src/registry/contract.rs
@@ -8,6 +8,7 @@ use crate::{
     registry::Publishable,
     util::{hash_string, MAX_BUMP},
     version::Version,
+    events::{Deploy, EventPublishable},
     Contract,
 };
 
@@ -24,14 +25,6 @@ loam_sdk::import_contract!(core_riff);
 //     loam_sdk::soroban_sdk::contractimport!(file = "../../target/loam/core_riff.wasm",);
 // }
 
-#[contracttype]
-pub struct DeployEventData {
-    published_name: String,
-    deployed_name: String,
-    version: Version,
-    deployer: Address,
-    contract_id: Address,
-}
 
 #[contracttype(export = false)]
 pub struct ContractRegistry(pub Map<String, Address>);
@@ -96,14 +89,14 @@ impl IsDeployable for ContractRegistry {
             },
             Ok,
         )?;
-        let deploy_datas = DeployEventData {
+        let deploy_data = Deploy {
             published_name: contract_name,
             deployed_name,
             version,
             deployer: owner,
             contract_id: address.clone(),
         };
-        env().events().publish((symbol_short!("deploy"),), deploy_datas);
+        deploy_data.publish_event(env());
 
         Ok(address)
     }

--- a/contracts/smartdeploy/src/registry/wasm.rs
+++ b/contracts/smartdeploy/src/registry/wasm.rs
@@ -7,18 +7,10 @@ use crate::{
     metadata::{ContractMetadata, PublishedContract, PublishedWasm},
     util::MAX_BUMP,
     version::{self, Version, INITAL_VERSION},
+    events::{Publish, EventPublishable},
 };
 
 use super::IsPublishable;
-
-#[contracttype]
-pub struct PublishEventData {
-    pub published_name: String,
-    pub author: Address,
-    pub wasm: soroban_sdk::Bytes,
-    pub repo: ContractMetadata,
-    pub kind: version::Update,
-}
 
 #[contracttype(export = false)]
 
@@ -108,14 +100,14 @@ impl IsPublishable for WasmRegistry {
         self.set_contract(contract_name.clone(), contract);
 
         // Publish a publish event
-        let publish_datas = PublishEventData {
+        let publish_data = Publish {
             published_name: contract_name,
             author,
             wasm,
             repo: metadata,
             kind: kind.unwrap_or_default(),
         };
-        env().events().publish((symbol_short!("publish"),), publish_datas);
+        publish_data.publish_event(env());
 
         Ok(())
     }

--- a/contracts/smartdeploy/src/registry/wasm.rs
+++ b/contracts/smartdeploy/src/registry/wasm.rs
@@ -94,8 +94,8 @@ impl IsPublishable for WasmRegistry {
         } else {
             contract.get(Some(last_version))?.metadata
         };
-        let hash = env().deployer().upload_contract_wasm(wasm.clone());
-        let published_binary = PublishedWasm { hash, metadata: metadata.clone() };
+        let hash = env().deployer().upload_contract_wasm(wasm);
+        let published_binary = PublishedWasm { hash: hash.clone(), metadata: metadata.clone() };
         contract.versions.set(new_version, published_binary);
         self.set_contract(contract_name.clone(), contract);
 
@@ -103,7 +103,7 @@ impl IsPublishable for WasmRegistry {
         let publish_data = Publish {
             published_name: contract_name,
             author,
-            wasm,
+            hash,
             repo: metadata,
             kind: kind.unwrap_or_default(),
         };

--- a/contracts/smartdeploy/src/test.rs
+++ b/contracts/smartdeploy/src/test.rs
@@ -72,7 +72,7 @@ fn publish_deploy_events() {
     let publish_data =  events::Publish {
         published_name: published_name.clone(),
         author: address.clone(),
-        wasm: bytes,
+        hash: env.deployer().upload_contract_wasm(bytes),
         repo: metadata::ContractMetadata::default(),
         kind: version::Update::default(),
     };

--- a/contracts/smartdeploy/src/version.rs
+++ b/contracts/smartdeploy/src/version.rs
@@ -70,7 +70,7 @@ impl Version {
 }
 
 #[contracttype]
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub enum Update {
     #[default]
     Patch,


### PR DESCRIPTION
First, we created a 'publish' event to index data every time a wasm file is published onto Soroban. Second, we gathered the events in the Rust module 'events'