### PR TITLE
feat!: Claimable trait for all contracts with no coreriff macro

### DIFF
--- a/contracts/smartdeploy/src/error.rs
+++ b/contracts/smartdeploy/src/error.rs
@@ -22,4 +22,10 @@ pub enum Error {
 
     /// Failed to initialize contract
     InitFailed = 7,
+
+    /// Failed to redeploy a deployed contract with no coreriff macro
+    RedeployDeployedFailed = 8,
+
+    /// Contract doesn't have owner, impossible to perform the operation 
+    NoOwnerSet = 9,
 }

--- a/contracts/smartdeploy/src/lib.rs
+++ b/contracts/smartdeploy/src/lib.rs
@@ -2,7 +2,7 @@
 use loam_sdk::{soroban_contract, soroban_sdk};
 use loam_sdk_core_riff::{owner::Owner, CoreRiff};
 use registry::{
-    contract::ContractRegistry, wasm::WasmRegistry, Deployable, DevDeployable, Publishable,
+    contract::ContractRegistry, wasm::WasmRegistry, Deployable, DevDeployable, Publishable, Claimable,
 };
 
 pub mod error;
@@ -21,6 +21,10 @@ impl Publishable for Contract {
 }
 
 impl Deployable for Contract {
+    type Impl = ContractRegistry;
+}
+
+impl Claimable for Contract {
     type Impl = ContractRegistry;
 }
 

--- a/contracts/smartdeploy/src/registry.rs
+++ b/contracts/smartdeploy/src/registry.rs
@@ -52,9 +52,6 @@ pub trait IsPublishable {
 
 #[riff]
 pub trait IsDeployable {
-    /// Claim a contract id of an already deployed contract
-    fn claim_deployed_contract(&mut self, deployed_name: soroban_sdk::String, id: soroban_sdk::Address) -> Result<(), Error>;
-
     /// Deploys a new published contract returning the deployed contract's id.
     /// If no salt provided it will use the current sequence number.
     fn deploy(
@@ -81,6 +78,31 @@ pub trait IsDeployable {
     ) -> Result<soroban_sdk::Vec<(soroban_sdk::String, soroban_sdk::Address)>, Error>;
 }
 
+#[riff]
+pub trait IsClaimable {
+    /// Claim a contract id of an already deployed contract
+    fn claim_already_deployed_contract(
+        &mut self,
+        deployed_name: soroban_sdk::String,
+        id: soroban_sdk::Address,
+        owner: soroban_sdk::Address,
+    ) -> Result<(), Error>;
+
+    /// Get the owner of a claimed deployed contract
+    fn get_claimed_owner(
+        &self,
+        deployed_name: soroban_sdk::String
+    ) -> Result<Option<soroban_sdk::Address>, Error>;
+
+    /// Redeploy a claimed deployed contract to a new wasm. Defaults: use redeploy from coreriff
+    fn redeploy_claimed_contract(
+        &self,
+        binary_name: Option<soroban_sdk::String>,
+        version: Option<Version>,
+        deployed_name: soroban_sdk::String,
+        redeploy_fn: Option<(soroban_sdk::Symbol, soroban_sdk::Vec<soroban_sdk::Val>)>,
+    ) -> Result<(), Error>;
+}
 
 #[riff]
 pub trait IsDevDeployable {

--- a/deploy.sh
+++ b/deploy.sh
@@ -47,6 +47,7 @@ echo $ID
 if test "$FILE_HASH" = ""; then
   just publish smartdeploy
   just claim_self
+  just set_owner default
 fi
 
 if test "$SOROBAN_NETWORK" = "testnet"; then

--- a/justfile
+++ b/justfile
@@ -75,8 +75,11 @@ setup_default:
     @./deploy.sh
 
 [private]
-@claim_self:
-    just smartdeploy claim_deployed_contract --deployed_name smartdeploy --id {{ id }}
+@claim_self owner='default':
+    just smartdeploy claim_already_deployed_contract --deployed_name smartdeploy --id {{ id }} --owner {{owner}}
+
+@set_owner owner:
+    @just smartdeploy_raw -- owner_set --new_owner {{ owner }} 
 
 [private]
 @install_self:


### PR DESCRIPTION
**What?**
Possibility to claim/ import a contract to SmartDeploy which hasn't been deployed with the smartdeploy-cli. We keep the notion of ownership and redeployment.

Add an admin/ owner to the smartdeploy contract (justfile)

**Why?**
The idea is to easily allow developer to integrate SmartDeploy to their already deployed contract. They also use the function `redeploy_claimed_contract` to add the macro `smartdeploy_sdk::core_riff`
